### PR TITLE
Unify Axios base URL

### DIFF
--- a/petHW/front/config.js
+++ b/petHW/front/config.js
@@ -1,0 +1,1 @@
+export const BASE_URL = 'http://localhost/petHW/backend/public';

--- a/petHW/front/doDelete.js
+++ b/petHW/front/doDelete.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doDelete(id){
     // let idValue;
     // for(let i=0; i<id.length; i++){
@@ -8,7 +10,7 @@ export default function doDelete(id){
     let data = {
         "id": id,
     };
-    axios.post("../backend/public/index.php?action=removeUser",Qs.stringify(data))
+    axios.post(`${BASE_URL}/index.php?action=removeUser`,Qs.stringify(data))
     
     .then(res => {
         let response = res['data'];

--- a/petHW/front/doDeletepet.js
+++ b/petHW/front/doDeletepet.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doDeletepet(id){
     // let idValue;
     // for(let i=0; i<id.length; i++){
@@ -8,7 +10,7 @@ export default function doDeletepet(id){
     let data = {
         "id": id,
     };
-    axios.post("../backend/public/index.php?action=removepet_information",Qs.stringify(data))
+    axios.post(`${BASE_URL}/index.php?action=removepet_information`,Qs.stringify(data))
     
     .then(res => {
         let response = res['data'];

--- a/petHW/front/doInsert.js
+++ b/petHW/front/doInsert.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doInsert(){
     let data = {
          // 取得所有表單資料
@@ -21,7 +23,7 @@ export default function doInsert(){
          return;
      }
     
-    axios.post("../backend/public/index.php?action=newUser", Qs.stringify(data))
+    axios.post(`${BASE_URL}/index.php?action=newUser`, Qs.stringify(data))
     .then(res => {
         let response = res['data'];
         

--- a/petHW/front/doInsertpet.js
+++ b/petHW/front/doInsertpet.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doInsertpet(){
 let data = {
          // 取得所有寵物表單資料
@@ -17,7 +19,7 @@ let data = {
          return;
      }
 
-    axios.post("../backend/public/index.php?action=newpet_information", Qs.stringify(data))
+    axios.post(`${BASE_URL}/index.php?action=newpet_information`, Qs.stringify(data))
     .then(res => {
         let response = res['data'];
         

--- a/petHW/front/doSelect.js
+++ b/petHW/front/doSelect.js
@@ -1,5 +1,7 @@
+import { BASE_URL } from "./config.js";
+
 export default function doSelect(){
-    axios.get("../backend/public/index.php?action=getUsers")
+    axios.get(`${BASE_URL}/index.php?action=getUsers`)
     .then(res => {
         let response = res['data'];
         switch(response['status']){

--- a/petHW/front/doSelectpet.js
+++ b/petHW/front/doSelectpet.js
@@ -1,6 +1,8 @@
+import { BASE_URL } from "./config.js";
+
 export default function doSelectpet(){
     // 修改 API 端點為寵物相關
-    axios.get("../backend/public/index.php?action=getpet_information")
+    axios.get(`${BASE_URL}/index.php?action=getpet_information`)
     .then(res => {
         let response = res['data'];
         switch(response['status']){

--- a/petHW/front/doUpdate.js
+++ b/petHW/front/doUpdate.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doUpdate(){
     let data = {
          "id": document.getElementById("id").value,
@@ -8,7 +10,7 @@ export default function doUpdate(){
         //這裡不能使用 .innerText  需要使用 .value、因為 <input> 裡面根本沒有 innerText
      };
      
-     axios.post("http://localhost/petHW/backend/public/index.php?action=updateUser", Qs.stringify(data))
+     axios.post(`${BASE_URL}/index.php?action=updateUser`, Qs.stringify(data))
      .then(res => {
          let response = res['data'];
          document.getElementById("content").innerHTML = response['message'];

--- a/petHW/front/doUpdatepet.js
+++ b/petHW/front/doUpdatepet.js
@@ -1,3 +1,5 @@
+import { BASE_URL } from "./config.js";
+
 export default function doUpdatepet(){
     let data = {
          "id": document.getElementById("id").value,
@@ -11,7 +13,7 @@ export default function doUpdatepet(){
         //這裡不能使用 .innerText  需要使用 .value、因為 <input> 裡面根本沒有 innerText
      };
      
-     axios.post("http://localhost/petHW/backend/public/index.php?action=updatepet_information", Qs.stringify(data))
+     axios.post(`${BASE_URL}/index.php?action=updatepet_information`, Qs.stringify(data))
      .then(res => {
          let response = res['data'];
          document.getElementById("content").innerHTML = response['message'];

--- a/petHW/front/petInfo.js
+++ b/petHW/front/petInfo.js
@@ -2,10 +2,11 @@
 import showInsertPage from "./showpetInsertPage.js";
 import showpetUpdatePage from "./showpetUpdatePage.js";
 import doDeletepet from "./doDeletepet.js";
+import { BASE_URL } from "./config.js";
 
 export default function petInfo(){
     // 錯誤2: 可能缺少錯誤處理，如果後端未運行或 API 路徑錯誤會導致未捕獲的異常
-    axios.get("http://localhost/petHW/backend/public/index.php?action=getpet_information")
+    axios.get(`${BASE_URL}/index.php?action=getpet_information`)
 
     .then(res => {
         let response = res['data'];

--- a/petHW/front/showUpdatePage.js
+++ b/petHW/front/showUpdatePage.js
@@ -1,11 +1,13 @@
 import doUpdate from './doUpdate.js';
+import { BASE_URL } from './config.js';
+
 export default function showUpdatePage(id){
 
     let data = {
         "id": id,
     };
     
-   axios.get("http://localhost/petHW/backend/public/index.php?action=getUsers", Qs.stringify(data))
+   axios.get(`${BASE_URL}/index.php?action=getUsers`, Qs.stringify(data))
     .then(res => {
         let response = res['data'];
         switch(response['status']){

--- a/petHW/front/showpetUpdatePage.js
+++ b/petHW/front/showpetUpdatePage.js
@@ -1,4 +1,5 @@
 import doUpdatepet from './doUpdatepet.js';
+import { BASE_URL } from './config.js';
 
 export default function showpetUpdatePage(id){
 
@@ -6,7 +7,7 @@ export default function showpetUpdatePage(id){
         "id": id,
     };
 
-   axios.get("http://localhost/petHW/backend/public/index.php?action=getpet_information", {params: data})
+   axios.get(`${BASE_URL}/index.php?action=getpet_information`, {params: data})
     .then(res => {
         let response = res['data'];
         switch(response['status']){

--- a/petHW/front/userInfo.js
+++ b/petHW/front/userInfo.js
@@ -1,9 +1,10 @@
 import showInsertPage from "./showInsertPage.js";
 import showUpdatePage from "./showUpdatePage.js";
 import doDelete from "./doDelete.js";
+import { BASE_URL } from "./config.js";
 
 export default function userInfo(){
-    axios.get("http://localhost/petHW/backend/public/index.php?action=getUsers")
+    axios.get(`${BASE_URL}/index.php?action=getUsers`)
 
     .then(res => {
         let response = res['data'];


### PR DESCRIPTION
## Summary
- centralize API base URL in `config.js`
- reference `BASE_URL` in CRUD modules

## Testing
- `node -e "import('./petHW/front/doDelete.js').then(()=>console.log('loaded doDelete'));"`
- `for f in doDelete.js doDeletepet.js doInsert.js doInsertpet.js doSelect.js doSelectpet.js doUpdate.js doUpdatepet.js petInfo.js showUpdatePage.js showpetUpdatePage.js userInfo.js; do node -e "import('./petHW/front/$f').then(()=>console.log('$f OK')).catch(e=>console.error('$f ERR',e));"; done`

------
https://chatgpt.com/codex/tasks/task_e_6848717c0164832c88ad412725fb2786