### PR TITLE
Enable photo uploads for pet info

### DIFF
--- a/petHW/backend/app/Controllers/pet.php
+++ b/petHW/backend/app/Controllers/pet.php
@@ -27,6 +27,15 @@ class pet extends Controller
         $age = $_POST['age'] ?? '';
         $description = $_POST['description'] ?? '';
         $photo = $_POST['photo'] ?? '';
+        if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+            $uploadDir = __DIR__ . '/../../public/uploads/';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+            $filename = uniqid() . '_' . basename($_FILES['photo']['name']);
+            move_uploaded_file($_FILES['photo']['tmp_name'], $uploadDir . $filename);
+            $photo = 'uploads/' . $filename;
+        }
         $status = $_POST['status'] ?? 'available';  // 預設為可收養
         $created_by = $_POST['created_by'] ?? '';
         
@@ -62,6 +71,15 @@ class pet extends Controller
         $age = $_POST['age'] ?? '';
         $description = $_POST['description'] ?? '';
         $photo = $_POST['photo'] ?? '';
+        if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+            $uploadDir = __DIR__ . '/../../public/uploads/';
+            if (!is_dir($uploadDir)) {
+                mkdir($uploadDir, 0777, true);
+            }
+            $filename = uniqid() . '_' . basename($_FILES['photo']['name']);
+            move_uploaded_file($_FILES['photo']['tmp_name'], $uploadDir . $filename);
+            $photo = 'uploads/' . $filename;
+        }
         $status = $_POST['status'] ?? '';
         $created_by = $_POST['created_by'] ?? '';
         

--- a/petHW/front/doInsertpet.js
+++ b/petHW/front/doInsertpet.js
@@ -1,23 +1,27 @@
 export default function doInsertpet(){
-let data = {
-         // 取得所有寵物表單資料
-         "id": document.getElementById("id").value,
-         "name": document.getElementById("name").value,
-         "species": document.getElementById("species").value,
-         "age": document.getElementById("age").value,
-         "description": document.getElementById("description").value,
-         "photo": document.getElementById("photo").value,
-         "status": document.getElementById("status").value,
-         "created_by": document.getElementById("created_by").value
-     };
-     // 簡單驗證
- if (!data.species) {
-         document.getElementById("content").innerHTML = 
-             `<div class="alert-message alert-error">寵物種類不可為空</div>`;
-         return;
-     }
+    const formData = new FormData();
+    formData.append('id', document.getElementById('id').value);
+    formData.append('name', document.getElementById('name').value);
+    const speciesValue = document.getElementById('species').value;
+    formData.append('species', speciesValue);
+    formData.append('age', document.getElementById('age').value);
+    formData.append('description', document.getElementById('description').value);
+    const file = document.getElementById('photo').files[0];
+    if (file) {
+        formData.append('photo', file);
+    }
+    formData.append('status', document.getElementById('status').value);
+    formData.append('created_by', document.getElementById('created_by').value);
+    // 簡單驗證
+    if (!speciesValue) {
+        document.getElementById("content").innerHTML =
+            `<div class="alert-message alert-error">寵物種類不可為空</div>`;
+        return;
+    }
 
-    axios.post("../backend/public/index.php?action=newpet_information", Qs.stringify(data))
+    axios.post("../backend/public/index.php?action=newpet_information", formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+    })
     .then(res => {
         let response = res['data'];
         

--- a/petHW/front/doUpdatepet.js
+++ b/petHW/front/doUpdatepet.js
@@ -1,17 +1,22 @@
 export default function doUpdatepet(){
-    let data = {
-         "id": document.getElementById("id").value,
-         "name": document.getElementById("name").value,
-         "species": document.getElementById("species").value,
-         "age": document.getElementById("age").value,
-         "description": document.getElementById("description").value,
-         "photo": document.getElementById("photo").value,
-         "status": document.getElementById("status").value,
-         "created_by": document.getElementById("created_by").value
-        //這裡不能使用 .innerText  需要使用 .value、因為 <input> 裡面根本沒有 innerText
-     };
-     
-     axios.post("http://localhost/petHW/backend/public/index.php?action=updatepet_information", Qs.stringify(data))
+    const formData = new FormData();
+    formData.append('id', document.getElementById('id').value);
+    formData.append('name', document.getElementById('name').value);
+    formData.append('species', document.getElementById('species').value);
+    formData.append('age', document.getElementById('age').value);
+    formData.append('description', document.getElementById('description').value);
+    const file = document.getElementById('photo').files[0];
+    if (file) {
+        formData.append('photo', file);
+    } else {
+        formData.append('photo', document.getElementById('old_photo').value);
+    }
+    formData.append('status', document.getElementById('status').value);
+    formData.append('created_by', document.getElementById('created_by').value);
+
+     axios.post("http://localhost/petHW/backend/public/index.php?action=updatepet_information", formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+     })
      .then(res => {
          let response = res['data'];
          document.getElementById("content").innerHTML = response['message'];

--- a/petHW/front/showpetInsertPage.js
+++ b/petHW/front/showpetInsertPage.js
@@ -4,6 +4,7 @@ import doInsertpet from './doInsertpet.js';
 export default function showpetInsertPage(){
     let str = `
         <div class="form-container">
+            <form id="petForm" enctype="multipart/form-data">
             <h2>寵物資料</h2>
             <table class="custom-table">
                 <tr>
@@ -51,6 +52,7 @@ export default function showpetInsertPage(){
                     </td>
                 </tr>
             </table>
+            </form>
         </div>
     `;
     document.getElementById("content").innerHTML = str;

--- a/petHW/front/showpetUpdatePage.js
+++ b/petHW/front/showpetUpdatePage.js
@@ -15,6 +15,7 @@ export default function showpetUpdatePage(id){
                 const row = rows[0];
                 
                 let str = `<div class="form-container">
+                <form id="petForm" enctype="multipart/form-data">
                 <h2>編輯寵物資料</h2>
                 <table class="custom-table">
                     <tr>
@@ -42,6 +43,7 @@ export default function showpetUpdatePage(id){
                         <td>
                             ${row['photo'] ? `<img src="${row['photo']}" width="100"><br>` : ''}
                             <input type="file" id="photo" accept="image/*">
+                            <input type="hidden" id="old_photo" value="${row['photo'] || ''}">
                         </td>
                     </tr>
                     <tr>
@@ -65,6 +67,7 @@ export default function showpetUpdatePage(id){
                         </td>
                     </tr>
                 </table>
+                </form>
                 </div>`;
 
                 document.getElementById("content").innerHTML = str;


### PR DESCRIPTION
## Summary
- support storing pet photos by uploading files
- use `multipart/form-data` in pet insert/update
- wrap forms in the pet insert/update pages
- store uploaded files in `backend/public/uploads`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684871805924832c9a1e7ac767f18bf3